### PR TITLE
HA

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ Entries are grouped in a `namespace`.
 
 See `server/server_test.go` for examples.
 
+## High Availability / Failover
+
+Rudimentary and experimental HA is possible via replication by using the `-p` peers list and `-i` self IP:host pair flags such as: `dracula-server -p "127.0.0.1:3509,127.0.0.1:3519,127.0.0.1:3529" -i 127.0.0.1:3529`. All peers in the cluster are listed, as well as the self IP and host in the cluster. These flags tell the dracula server to replicate all PUT messages to peers.
+
+In practice, replicatoin only meets the use case of short-lived, imperfectly consistent metrics. We run it behind HAProxy and recommend you do the same, though you could implement a wrapper on the client side as well.
+
+If you require exact replication across peers, this feature will not be tolerant to network partitioning and not meet your needs.
+
 ## Limitations
 
 Messages are sent over UDP and not reliable. The trade-off desired is speed. This project was initially implemented to
@@ -186,8 +194,8 @@ is running in a trusted environment.
 
 ## Roadmap
 
-- High Availability
 - Persistence
+- Better support for high availability under network partitions 
 - Clients in other languages
 - Retries
 - Pipelining

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ import (
 )
 
 const (
-	serverPort = 3509
+	// include just one server or comma-separated pool
+    serverIPPortPool = "127.0.0.1:3509,192.168.0.1:3509"
 	namespace  = "default"
 )
 
@@ -143,7 +144,7 @@ var (
 )
 
 func main() {
-	c := client.NewClient("127.0.0.1", serverPort, clientResponseTimeout, "very-secure3")
+	c := client.NewClient(serverIPPortPool, clientResponseTimeout, "very-secure3")
 	c.Listen(9001)
 
 	// seed some entries
@@ -171,11 +172,21 @@ See `server/server_test.go` for examples.
 
 ## High Availability / Failover
 
-Rudimentary and experimental HA is possible via replication by using the `-p` peers list and `-i` self IP:host pair flags such as: `dracula-server -p "127.0.0.1:3509,127.0.0.1:3519,127.0.0.1:3529" -i 127.0.0.1:3529`. All peers in the cluster are listed, as well as the self IP and host in the cluster. These flags tell the dracula server to replicate all PUT messages to peers.
+Rudimentary and experimental HA is possible via replication by using the `-p` peers list and `-i` self `IP:host` pair flags such as:
+```
+dracula-server -p "127.0.0.1:3509,127.0.0.1:3519,127.0.0.1:3529" -i 127.0.0.1:3529
+```
 
-In practice, replicatoin only meets the use case of short-lived, imperfectly consistent metrics. We run it behind HAProxy and recommend you do the same, though you could implement a wrapper on the client side as well.
+where clients can connect to the pool and maintain a list of `-i` servers:
+```
+dracula-cli -i "127.0.0.1:3509,127.0.0.1:3519,127.0.0.1:3529" [...more flags]
+```
 
-If you require exact replication across peers, this feature will not be tolerant to network partitioning and not meet your needs.
+All peers in the cluster are listed, as well as the self IP and host in the cluster. These flags tell the dracula server to replicate all PUT messages to peers.
+
+In practice, replication only meets the use case of short-lived, imperfectly consistent metrics.
+
+If you require exact replication across peers, this feature will not be tolerant to network partitioning and will not meet your needs.
 
 ## Limitations
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -14,24 +14,24 @@ func TestClient_Auth(t *testing.T) {
 	// there are already tests with empty secret as well
 
 	secret := "asdf-jkl-HOHOHO!"
-	badSecret := "Brute-Force9"
 	s := server.NewServer(60, secret)
+	s.DebugEnable("9000")
 	err := s.Listen(9000)
 	if err != nil {
 		t.Fatal(err)
 	}
-	s.DebugEnable("9000")
 	defer s.Close()
 
-	goodClient := NewClient("127.0.0.1", 9000, 5, secret)
+	goodClient := NewClient("127.0.0.1:9000", 5, secret)
+	goodClient.DebugEnable("9001")
 	err = goodClient.Listen(9001)
 	if err != nil {
 		t.Fatal(err)
 	}
-	goodClient.DebugEnable("9001")
 	defer goodClient.Close()
 
-	badClient := NewClient("127.0.0.1", 9000, 5, badSecret)
+	// START with good secret so it can connect to server in pool, then switch to bad later
+	badClient := NewClient("127.0.0.1:9000", 5, secret)
 	err = badClient.Listen(9002)
 	if err != nil {
 		t.Fatal(err)
@@ -54,13 +54,48 @@ func TestClient_Auth(t *testing.T) {
 	}
 
 	// bad client checks, put same and count same
+
+	// pre-check
+	assert.Equal(t, "[127.0.0.1:9000]", badClient.pool.ListHealthy())
+	// change to BAD secret!
+	badClient.preSharedKey = []byte("Brute-Force9")
 	err = badClient.Put("asdf", "99.33.22.44")
 	assert.Error(t, err)
 	assert.Equal(t, "auth failed: packet hash invalid", err.Error())
 }
 
+func TestClient_Healthcheck(t *testing.T) {
+	s1 := server.NewServer(60, "sec1")
+	s1.DebugEnable("9000")
+	err := s1.Listen(9000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s1.Close()
+
+	s2 := server.NewServer(60, "sec1")
+	s2.DebugEnable("9100")
+	err = s2.Listen(9100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s2.Close()
+
+	c1 := NewClient("127.0.0.1:9000,127.0.0.1:9100,127.0.0.1:99999", 5, "sec1")
+	c1.pool.Debug = true
+	c1.DebugEnable("9001")
+	err = c1.Listen(9001)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c1.Close()
+	assert.Equal(t, "[127.0.0.1:9000 127.0.0.1:9100 127.0.0.1:99999]", c1.pool.ListServers(), "did not parse servers correctly")
+	assert.Equal(t, "[127.0.0.1:9000 127.0.0.1:9100]", c1.pool.ListHealthy())
+	assert.Equal(t, "[127.0.0.1:99999]", c1.pool.ListUnHealthy())
+}
+
 func TestClient_messageIDOverflow(t *testing.T) {
-	cl := NewClient("127.0.0.1", 9000, time.Second*5, "")
+	cl := NewClient("127.0.0.1:9000", time.Second*5, "")
 	cl.messageIDCounter = math.MaxUint32 - 1
 	actual := protocol.Uint32FromBytes(cl.makeMessageID())
 	assert.Equal(t, uint32(math.MaxUint32), actual)
@@ -71,7 +106,7 @@ func TestClient_messageIDOverflow(t *testing.T) {
 }
 
 func TestClient_messageIDThreadSafe(t *testing.T) {
-	cl := NewClient("127.0.0.1", 9000, time.Second*5, "")
+	cl := NewClient("127.0.0.1:9000", time.Second*5, "")
 	var wg sync.WaitGroup
 	const expected uint32 = 5001
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -20,7 +20,7 @@ func TestClient_Auth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s.Debug = true
+	s.DebugEnable("9000")
 	defer s.Close()
 
 	goodClient := NewClient("127.0.0.1", 9000, 5, secret)
@@ -28,7 +28,7 @@ func TestClient_Auth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	goodClient.Debug = true
+	goodClient.DebugEnable("9001")
 	defer goodClient.Close()
 
 	badClient := NewClient("127.0.0.1", 9000, 5, badSecret)
@@ -36,7 +36,7 @@ func TestClient_Auth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	badClient.Debug = true
+	badClient.DebugEnable("9002")
 	defer badClient.Close()
 
 	// good client checks

--- a/client/serverpool/serverpool.go
+++ b/client/serverpool/serverpool.go
@@ -1,0 +1,111 @@
+package serverpool
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"sync"
+	"time"
+)
+
+const (
+	healthLoopDurationHealthy   = 6 * time.Second
+	healthLoopDurationUnHealthy = 1 * time.Second
+)
+
+type Healthchecker interface {
+	Healthcheck(specificServer *net.UDPAddr) error
+}
+
+type Pool struct {
+	sync.Mutex
+	checker   Healthchecker
+	servers   []*net.UDPAddr
+	healthy   []*net.UDPAddr
+	unhealthy []*net.UDPAddr
+	disposed  bool
+	Debug     bool
+}
+
+func NewPool(getChecker Healthchecker, servers []*net.UDPAddr) *Pool {
+	p := &Pool{
+		checker: getChecker,
+		servers: servers,
+	}
+	return p
+}
+
+func (p *Pool) Listen() {
+	// seed health and unhealthy servers immediately
+	healthy, unhealthy := p.healthcheck()
+	p.Lock()
+	p.healthy = healthy
+	p.unhealthy = unhealthy
+	p.Unlock()
+
+	go p.loopHealthcheck()
+}
+
+// healthcheck is slow and should not block the main thread
+func (p *Pool) loopHealthcheck() {
+	if p.disposed {
+		return
+	}
+	healthy, unhealthy := p.healthcheck()
+	p.Lock()
+	p.healthy = healthy
+	p.unhealthy = unhealthy
+	p.Unlock()
+
+	if len(healthy) > 0 {
+		time.Sleep(healthLoopDurationHealthy)
+	} else {
+		time.Sleep(healthLoopDurationUnHealthy)
+	}
+	p.loopHealthcheck()
+}
+
+func (p *Pool) healthcheck() (healthy, unhealthy []*net.UDPAddr) {
+	var err error
+	for _, s := range p.servers {
+		err = p.checker.Healthcheck(s)
+		if err != nil {
+			unhealthy = append(unhealthy, s)
+			if p.Debug {
+				fmt.Println("dracula pool server unhealthy", s, err)
+			}
+		} else {
+			healthy = append(healthy, s)
+		}
+	}
+	return healthy, unhealthy
+}
+
+func (p *Pool) Choose() *net.UDPAddr {
+	p.Lock()
+	defer p.Unlock()
+	l := len(p.healthy)
+	if l < 1 {
+		return nil
+	}
+	if l == 1 {
+		return p.healthy[0]
+	}
+	ix := rand.Intn(l)
+	return p.healthy[ix]
+}
+
+func (p *Pool) ListServers() string {
+	return fmt.Sprintf("%v", p.servers)
+}
+
+func (p *Pool) ListHealthy() string {
+	return fmt.Sprintf("%v", p.healthy)
+}
+func (p *Pool) ListUnHealthy() string {
+	return fmt.Sprintf("%v", p.unhealthy)
+}
+
+func (p *Pool) Dispose() {
+	p.disposed = true
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -9,14 +9,13 @@ import (
 )
 
 var (
-	ip           = flag.String("i", "127.0.0.1", "Server IP to connect to")
+	ipPortPairs  = flag.String("i", "127.0.0.1:3509", "List of one or more comma-separated server <ip:port> to connect to")
 	ns           = flag.String("n", "default", "Entry key namespace value")
 	entryKey     = flag.String("k", "", "Required: entry key")
 	count        = flag.Bool("count", false, "Mode: Count items at entry key")
 	put          = flag.Bool("put", false, "Mode: Put item at entry key")
-	port         = flag.Int("p", 3509, "Server port to connect to")
 	secret       = flag.String("s", "", "Optional pre-shared auth secret if not using env var DRACULA_SECRET")
-	localPort    = flag.Int("lp", 3510, "Local client port to receive responses on")
+	localPort    = flag.Int("p", 3510, "Local client port to receive responses on")
 	timeoutSecs  = flag.Int64("t", 6, "Request timeout in seconds")
 	help         = flag.Bool("h", false, "Print help")
 	verbose      = flag.Bool("v", false, "Verbose logging")
@@ -60,9 +59,9 @@ func main() {
 		preSharedSecret = *secret
 	}
 
-	c := client.NewClient(*ip, *port, time.Duration(*timeoutSecs)*time.Second, preSharedSecret)
+	c := client.NewClient(*ipPortPairs, time.Duration(*timeoutSecs)*time.Second, preSharedSecret)
 	if *verbose {
-		c.DebugEnable(fmt.Sprintf("%d", *port))
+		c.DebugEnable(fmt.Sprintf("%d", *localPort))
 	}
 	err := c.Listen(*localPort)
 	if err != nil {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -62,7 +62,7 @@ func main() {
 
 	c := client.NewClient(*ip, *port, time.Duration(*timeoutSecs)*time.Second, preSharedSecret)
 	if *verbose {
-		c.Debug = true
+		c.DebugEnable(fmt.Sprintf("%d", *port))
 	}
 	err := c.Listen(*localPort)
 	if err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/mailsac/dracula/server"
 	"os"
+	"strings"
 	"sync"
 )
 
@@ -13,6 +14,8 @@ var (
 	expireAfterSecs = flag.Int64("t", 60, "TTL secs - entries will expire after this many seconds")
 	port            = flag.Int("p", 3509, "Port this server will run on")
 	secret          = flag.String("s", "", "Optional pre-shared auth secret if not using env var DRACULA_SECRET")
+	peerIPPort      = flag.String("i", "", "Self peer IP and host like 192.168.0.1:3509 to identify self in the cluster")
+	peers           = flag.String("c", "", "Enable cluster replication. Peers must be comma-separated ip:port like `192.168.0.1:3509,192.168.0.2:3555`.")
 	verbose         = flag.Bool("v", false, "Verbose logging")
 	printVersion    = flag.Bool("version", false, "Print version")
 )
@@ -37,9 +40,23 @@ func main() {
 	if *secret != "" {
 		preSharedSecret = *secret
 	}
-	s := server.NewServer(*expireAfterSecs, preSharedSecret)
+	var s *server.Server
+	peerList := strings.Trim(*peers, " \n")
+	if len(peerList) > 0 && *peerIPPort == "" {
+		flag.Usage()
+		fmt.Println("peer list and self peer ip:port are required together")
+		os.Exit(1)
+	}
+	if len(peerList) > 0 {
+		s = server.NewServerWithPeers(*expireAfterSecs, preSharedSecret, *peerIPPort, peerList)
+		if *verbose {
+			fmt.Printf("dracula server cluster mode enabled: self=%s; peers=%s \n", *peerIPPort, s.Peers())
+		}
+	} else {
+		s = server.NewServer(*expireAfterSecs, preSharedSecret)
+	}
 	if *verbose {
-		s.Debug = true
+		s.DebugEnable(fmt.Sprintf("%d", *port))
 	}
 	err := s.Listen(*port)
 	if err != nil {

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -17,6 +17,7 @@ const (
 
 	CmdCount          byte = 'C'
 	CmdPut            byte = 'P'
+	CmdPutReplicate   byte = 'R'
 	CmdCountNamespace byte = 'N'
 	CmdCountServer    byte = 'S'
 	ResError          byte = 'E'
@@ -40,7 +41,7 @@ var (
 
 // IsRequestCmd indicates if the server should accept this as a command
 func IsRequestCmd(c byte) bool {
-	return c == CmdCount || c == CmdPut || c == CmdCountNamespace || c == CmdCountServer
+	return c == CmdCount || c == CmdPut || c == CmdCountNamespace || c == CmdCountServer || c == CmdPutReplicate
 }
 
 // IsResponseCmd indicates if the client should accept this as a command


### PR DESCRIPTION
1. servers will replicate packets with new command - must have 2 CLI flags
1. child logger for server/client
1. client has pool of servers and checks health
1. note the changes in client and server pre-built apps - slight changes to CLI flags
1. it's not perfect, but for short-lived metrics it should exceed 80/20 rule