### PR TITLE
Update server.go to reduce race condition in test suite

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -132,11 +132,11 @@ func (s *Server) Close() error {
 		return nil
 	}
 	s.disposed = true
+	udpErr := s.conn.Close()
+	tcpErr := s.tcpConn.Close()
 
 	s.store.DisableCleanup()
 	close(s.messageProcessing)
-	udpErr := s.conn.Close()
-	tcpErr := s.tcpConn.Close()
 
 	if udpErr != nil {
 		return udpErr


### PR DESCRIPTION
Change the udpErr and tcpErr to close earlier in the close function of server.go to reduce likelihood of race condition in test suite where TestClient_Auth, TestClient_Healthcheck, and TestClient_TcpKeyMatch/returns_ordered_keys_with_secret intermittently fail because the udp address is detected as already being in use.

Screenshot of failing tests
![failing tests dracula](https://github.com/mailsac/dracula/assets/48573294/cb1d7cf9-b518-40a0-be6e-a0aa9f0d987c)

After correction
![after fixing code](https://github.com/mailsac/dracula/assets/48573294/4fcffb63-a11c-4d94-abed-a52fc6c39c94)

